### PR TITLE
Catalog App: Add Schema for Game and Author

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,13 +1,3 @@
--- Create Game table 
-CREATE TABLE Game {
-  id INTEGER GENERATED ALWAYS AS IDENTITY,
-  multiplayer BOOLEAN NOT NULL,
-  last_played_at DATE NOT NULL
-  item_id INTEGER,
-  PRIMARY KEY(id),
-  CONSTRAINT fk_item FOREIGN KEY(item_id) references Item(id) ON DELETE CASCADE
-};
-
 -- Create Author table 
 CREATE TABLE Author {
   id INTEGER GENERATED ALWAYS AS IDENTITY,
@@ -15,3 +5,28 @@ CREATE TABLE Author {
   last_name VARCHAR(100),
   PRIMARY KEY(id)
 };
+
+-- Create Item table
+CREATE TABLE item (
+	id  INT GENERATED ALWAYS AS IDENTITY,
+	genre_id INT,
+	author_id INT,
+	label_id INT,
+	publish_date DATE,
+	archived BOOLEAN,
+	PRIMARY KEY(id),
+	FOREIGN KEY (genre_id) REFERENCES genres (id),
+	FOREIGN KEY (author_id) REFERENCES author (id),
+	FOREIGN KEY (label_id) REFERENCES label (id)
+);
+
+-- Create Game table 
+CREATE TABLE Game {
+  id INTEGER GENERATED ALWAYS AS IDENTITY,
+  multiplayer BOOLEAN NOT NULL,
+  last_played_at DATE NOT NULL,
+  item_id INTEGER,
+  PRIMARY KEY(id),
+  CONSTRAINT fk_item FOREIGN KEY(item_id) references item(id) ON DELETE CASCADE
+};
+

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,17 @@
+-- Create Game table 
+CREATE TABLE Game {
+  id INTEGER GENERATED ALWAYS AS IDENTITY,
+  multiplayer BOOLEAN NOT NULL,
+  last_played_at DATE NOT NULL
+  item_id INTEGER,
+  PRIMARY KEY(id),
+  CONSTRAINT fk_item FOREIGN KEY(item_id) references Item(id) ON DELETE CASCADE
+};
+
+-- Create Author table 
+CREATE TABLE Author {
+  id INTEGER GENERATED ALWAYS AS IDENTITY,
+  first_name VARCHAR(100),
+  last_name VARCHAR(100),
+  PRIMARY KEY(id)
+};


### PR DESCRIPTION
## Summary
- In this pull request, I created a `schema.sql` file which contains a schema of two tables: `Game` and `Author`

## Changes log
 - [x] Created schema for Table `Game`
 - [x] Created schema for Table `Author`

## Acceptance criteria
- [x] `Schema.sql` should be able to create 2 tables `Author` and `Game` according to Diagram.
- [x] `Game` and `Author` should contain every field and handle the relationship between tables
